### PR TITLE
add lazy_data type

### DIFF
--- a/cameca.ksy
+++ b/cameca.ksy
@@ -1421,14 +1421,8 @@ types:
         type: u4
       - id: size
         type: u4
-    instances:
-      bytes:
-        io: _root._io
-        pos: offset
-        size: size
-        doc: "raw bytes"
     seq:
-      - id: parsed_bytes
+      - id: bytes
         size: size
         doc: |
           this needs to be get rid off in target language and replaced with

--- a/cameca.ksy
+++ b/cameca.ksy
@@ -793,7 +793,7 @@ types:
         type: f4
       - id: enabled
         type: u4
-        doc: is used in calculations of stat parameters
+        doc: is this item used in calculations
       - id: peak_raw_cts
         type: s4
       - id: bkgd_1_raw_cts
@@ -1426,9 +1426,13 @@ types:
         io: _root._io
         pos: offset
         size: size
+        doc: "raw bytes"
     seq:
-      - id: dummy_data
+      - id: parsed_bytes
         size: size
+        doc: |
+          this needs to be get rid off in target language and replaced with
+          relative seek.
   
   wds_scan_spect_setup:
     seq:

--- a/cameca.ksy
+++ b/cameca.ksy
@@ -644,7 +644,7 @@ types:
           (dataset_type != dataset_type::line_stage) and
           (dataset_type != dataset_type::line_beam)
       - id: data
-        size: frame_size
+        type: lazy_data(_root._io.pos, frame_size)
         repeat: expr
         repeat-expr: n_of_frames
         doc: |
@@ -793,7 +793,7 @@ types:
         type: f4
       - id: enabled
         type: u4
-        doc: use in calculations
+        doc: is used in calculations of stat parameters
       - id: peak_raw_cts
         type: s4
       - id: bkgd_1_raw_cts
@@ -916,7 +916,7 @@ types:
       - id: data_array_size
         type: u4
       - id: data
-        size: data_array_size
+        type: lazy_data(_root._io.pos, data_array_size)
       - id: not_re_flag
         type: u4
       - id: signal_name
@@ -1411,6 +1411,25 @@ types:
         type: qti_wds_measurement_setups
         if: wds_measurement_struct_type >= 19
   
+  lazy_data:
+    doc: |
+          its _read method needs to be reimplemented in target language
+          to seek in the stream by provided size by parameter instead
+          of reading into memory
+    params:
+      - id: offset
+        type: u4
+      - id: size
+        type: u4
+    instances:
+      bytes:
+        io: _root._io
+        pos: offset
+        size: size
+    seq:
+      - id: dummy_data
+        size: size
+  
   wds_scan_spect_setup:
     seq:
       - id: xtal
@@ -1572,7 +1591,7 @@ types:
       unix_timestamp:
         value: ms_filetime / 10000000. - 11644473600
         doc: 'seconds since Jan 1 1970'
-  
+
   element_t:
     seq:
       - id: atomic_number


### PR DESCRIPTION
It is not completely lazy (As title suggests). To achieve that target language needs to
re-implement _read method for lazy_data class to seek the size amount instead  of
reading into memory. Also some data deleter method (or decorator) needs to be implemented.
This is kind of work around kaitai_struct limitation of missing skip functionality.

Use case is for very massive WDS, and multiframe multi dataset impDat and impWds files.